### PR TITLE
Infer depth from the shape

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,7 +34,7 @@ Prints any of the files in the shape that are missing from the repo.`,
 			return err
 		}
 
-		missing, err := shape.Missing(args[0], shapeData, 0)
+		missing, err := shape.Missing(args[0], shapeData)
 		if err != nil {
 			return err
 		}

--- a/shape/verify_test.go
+++ b/shape/verify_test.go
@@ -7,47 +7,64 @@ import (
 )
 
 func TestMissing(t *testing.T) {
-	shape := []byte(`
-		README.md
-		LICENSE
-		.github/workflows/
-		go.mod
-	`)
-
 	testCases := []struct {
 		name     string
 		shape    []byte
 		root     string
-		depth    int
 		expected map[string]bool
 	}{
 		{
-			name:     "NoneMissingDefaultDepth",
-			root:     "./testdata",
-			shape:    shape,
-			depth:    0,
+			name: "NoneMissing",
+			root: "./testdata",
+			shape: []byte(`
+				README.md
+				LICENSE
+				.github/workflows/
+				go.mod
+			`),
 			expected: map[string]bool{},
 		},
-		{
-			name:     "NoneMissingHighDepth",
-			root:     "./testdata",
-			shape:    shape,
-			depth:    10,
-			expected: map[string]bool{},
-		},
-		{name: "MissingNestedDir",
-			root:  "./testdata",
-			shape: shape,
-			depth: 1,
+		{name: "MissingDir",
+			root: "./testdata",
+			shape: []byte(`
+				README.md
+				LICENSE
+				go.mod
+				.vscode/
+			`),
 			expected: map[string]bool{
-				".github/workflows": true,
+				".vscode": true,
+			},
+		},
+		{name: "MissingFile",
+			root: "./testdata",
+			shape: []byte(`
+				README.md
+				LICENSE
+				go.mod
+				.env
+			`),
+			expected: map[string]bool{
+				".env": false,
+			},
+		},
+		{name: "MissingNestedFile",
+			root: "./testdata",
+			shape: []byte(`
+				README.md
+				LICENSE
+				go.mod
+				.vscode/settings.json
+			`),
+			expected: map[string]bool{
+				".vscode/settings.json": false,
 			},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual, err := Missing(tc.root, tc.shape, tc.depth)
+			actual, err := Missing(tc.root, tc.shape)
 			assert.Nil(t, err)
 
 			assert.Len(t, actual, len(tc.expected))


### PR DESCRIPTION
Removed `shape.Missing`'s `depth` argument because we can infer how deep we should check from the shape file. It was also awkward since `shape.Missing` took it as an argument but the command didn't have a flag for it.