### PR TITLE
Refactor to use Shape struct

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,7 +17,7 @@ var cfgFile string
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:     "dblstd <repo_path>",
-	Version: "0.0.2",
+	Version: "0.1.0",
 	Short:   "checks if a repo conforms to a given standard",
 	Long: `dblstd - short for DoubleStandards - checks if a project repo
 conforms to a given standard (in the form of a "shape" file).

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,12 +30,16 @@ Prints any of the files in the shape that are missing from the repo.`,
 		if err != nil {
 			return err
 		}
-		shapeData, err := ioutil.ReadFile(shapeFile)
+		shapeSpec, err := ioutil.ReadFile(shapeFile)
 		if err != nil {
 			return err
 		}
-
-		missing, err := shape.Missing(args[0], shapeData)
+		s, err := shape.NewShape(shapeSpec)
+		if err != nil {
+			return err
+		}
+		rootDir := args[0]
+		missing, err := s.Missing(rootDir)
 		if err != nil {
 			return err
 		}

--- a/shape/shape.go
+++ b/shape/shape.go
@@ -6,12 +6,26 @@ import (
 	"strings"
 )
 
+type Paths map[string]bool
+
+type Shape struct {
+	paths Paths
+}
+
+func NewShape(spec []byte) (*Shape, error) {
+	paths, err := parse(spec)
+	if err != nil {
+		return nil, err
+	}
+	return &Shape{paths}, nil
+}
+
 // Parse takes a slice of bytes representing a shape and returns map of paths.
 // If the path represents a directory the value is true, otherwise false.
-func Parse(f []byte) (map[string]bool, error) {
+func parse(spec []byte) (Paths, error) {
 	// Keeps track of the directory we're in
-	paths := make(map[string]bool)
-	reader := bytes.NewReader(f)
+	paths := Paths{}
+	reader := bytes.NewReader(spec)
 	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())

--- a/shape/shape_test.go
+++ b/shape/shape_test.go
@@ -8,19 +8,19 @@ import (
 
 func TestParse(t *testing.T) {
 	testCases := []struct {
-		name   string
-		shape  []byte
-		result map[string]bool
+		name      string
+		shapeSpec []byte
+		result    Paths
 	}{
 		{
 			name: "NoBlankLines",
-			shape: []byte(`
+			shapeSpec: []byte(`
 				README.md
 				LICENSE
 				.github/workflows/
 				go.mod
 			`),
-			result: map[string]bool{
+			result: Paths{
 				"README.md":         false,
 				"LICENSE":           false,
 				".github/workflows": true,
@@ -29,7 +29,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name: "WithBlankLines",
-			shape: []byte(`
+			shapeSpec: []byte(`
 					README.md
 
 					LICENSE
@@ -39,7 +39,7 @@ func TestParse(t *testing.T) {
 					
 					go.mod
 				`),
-			result: map[string]bool{
+			result: Paths{
 				"README.md":         false,
 				"LICENSE":           false,
 				".github/workflows": true,
@@ -50,10 +50,10 @@ func TestParse(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := Parse(tc.shape)
+			s, err := NewShape(tc.shapeSpec)
 			assert.Nil(t, err)
-			assert.Equal(t, len(result), len(tc.result))
-			for path, isDir := range result {
+			assert.Equal(t, len(s.paths), len(tc.result))
+			for path, isDir := range s.paths {
 				_, ok := tc.result[path]
 				assert.True(t, ok)
 				assert.Equal(t, tc.result[path], isDir)

--- a/shape/verify.go
+++ b/shape/verify.go
@@ -1,7 +1,6 @@
 package shape
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,14 +10,9 @@ import (
 // shape file returning any items missing required paths.
 // The depth argument controls how deep to walk through the repo. By default
 // we walk through the whole repo.
-func Missing(repoPath string, shape []byte) (map[string]bool, error) {
-	requiredPaths, err := Parse(shape)
-	if err != nil {
-		return nil, err
-	}
-
+func (s *Shape) Missing(repoPath string) (Paths, error) {
 	var depth int
-	for path := range requiredPaths {
+	for path := range s.paths {
 		depth = max(depth, strings.Count(path, "/")+1)
 	}
 	paths, err := walkDir(repoPath, depth)
@@ -29,19 +23,18 @@ func Missing(repoPath string, shape []byte) (map[string]bool, error) {
 	seen := make(map[string]bool)
 
 	for _, path := range paths {
-		if _, ok := requiredPaths[path]; ok {
+		if _, ok := s.paths[path]; ok {
 			seen[path] = true
 		}
 	}
 
-	if len(seen) < len(requiredPaths) {
-		missing := make(map[string]bool)
-		for path, isDir := range requiredPaths {
+	if len(seen) < len(s.paths) {
+		missing := Paths{}
+		for path, isDir := range s.paths {
 			if _, ok := seen[path]; !ok {
 				missing[path] = isDir
 			}
 		}
-		fmt.Printf("missing: %v\n", missing)
 		return missing, nil
 	}
 	return nil, nil

--- a/shape/verify_test.go
+++ b/shape/verify_test.go
@@ -64,7 +64,9 @@ func TestMissing(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual, err := Missing(tc.root, tc.shape)
+			s, err := NewShape(tc.shape)
+			assert.Nil(t, err)
+			actual, err := s.Missing(tc.root)
 			assert.Nil(t, err)
 
 			assert.Len(t, actual, len(tc.expected))


### PR DESCRIPTION
## Proposed Changes
- Add a Paths type to encapsulate the `map[string]bool` type that we have littered all over the place.
- Create `Shape` container to hold the paths. Make `Missing` a method of this type. The reasoning is that we don't want to keep calling `parse()` all over the place when we can just have the parsed paths in memory. It's less coordination.
- Rename parse.go to shape.go. Makes more sense now with the type there.